### PR TITLE
Update Transport.cs

### DIFF
--- a/src/SwissTransport/Transport.cs
+++ b/src/SwissTransport/Transport.cs
@@ -8,6 +8,7 @@ namespace SwissTransport
     {
         public Stations GetStations(string query)
         {
+            query = System.Uri.EscapeDataString(query);
             var request = CreateWebRequest("http://transport.opendata.ch/v1/locations?query=" + query);
             var response = request.GetResponse();
             var responseStream = response.GetResponseStream();
@@ -25,7 +26,9 @@ namespace SwissTransport
 
         public StationBoardRoot GetStationBoard(string station, string id)
         {
-            var request = CreateWebRequest("http://transport.opendata.ch/v1/stationboard?Station=" + station + "&id=" + id);
+            station = System.Uri.EscapeDataString(station);
+            id = System.Uri.EscapeDataString(id);
+            var request = CreateWebRequest("http://transport.opendata.ch/v1/stationboard?station=" + station + "&id=" + id);
             var response = request.GetResponse();
             var responseStream = response.GetResponseStream();
 
@@ -40,9 +43,11 @@ namespace SwissTransport
             return null;
         }
 
-        public Connections GetConnections(string fromStation, string toStattion)
+        public Connections GetConnections(string fromStation, string toStation)
         {
-            var request = CreateWebRequest("http://transport.opendata.ch/v1/connections?from=" + fromStation + "&to=" + toStattion);
+            fromStation = System.Uri.EscapeDataString(fromStation);
+            toStation = System.Uri.EscapeDataString(toStation);
+            var request = CreateWebRequest("http://transport.opendata.ch/v1/connections?from=" + fromStation + "&to=" + toStation);
             var response = request.GetResponse();
             var responseStream = response.GetResponseStream();
 


### PR DESCRIPTION
I fixed the mentioned issue, it is just bad Library design: 

> "stationboard?Station=Luzern&id="

 works while 

> "stationboard?Station=Luzern"

 doesn't. I also escaped all the url parameters so bad user input doesn't mess  everything up.